### PR TITLE
Fix `net.IP` encoding

### DIFF
--- a/cmd/view-packets/main.go
+++ b/cmd/view-packets/main.go
@@ -53,6 +53,7 @@ func main() {
 			filenames := args
 
 			filterPacket := func(packet gopacket.Packet) bool {
+				logrus.Debugf("Packet: %+v", packet)
 				if tcpLayer := packet.Layer(layers.LayerTypeTCP); tcpLayer != nil {
 					logrus.Debugf("This is a TCP packet.")
 					tcp, _ := tcpLayer.(*layers.TCP)


### PR DESCRIPTION
Go uses an IPv6-length slice of bytes under the hood by default for `net.IP` values.  When encoding, we now force this to an IPv4 address so that it only writes the correct number of bytes.

In addition, when writing a slice of bytes, we pad it with zeros if it's too small.